### PR TITLE
Add chainlit-aki package configuration

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
     needs: [ci]
     env:
       name: pypi
-      url: https://pypi.org/p/chainlit
+      url: https://pypi.org/p/chainlit-aki
       BACKEND_DIR: ./backend
     permissions:
       contents: read
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: aki
       - uses: ./.github/actions/pnpm-node-install
         name: Install Node, pnpm and dependencies.
         with:

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,19 @@
+NOTICE
+
+This project is a fork of Chainlit, originally developed by The Chainlit team.
+
+Original Project: https://github.com/Chainlit/chainlit
+Original Copyright: Copyright 2023- The Chainlit team. All rights reserved.
+
+This fork is maintained by AKI and is distributed under the same Apache License 2.0.
+
+The original Chainlit project can be found at:
+- Repository: https://github.com/Chainlit/chainlit
+- Website: https://chainlit.io/
+- Documentation: https://docs.chainlit.io/
+
+This fork maintains compatibility with the original Chainlit API and does not contain
+significant modifications to the core functionality.
+
+All original copyright notices, patent, trademark, and attribution notices from the
+source form of the original work are retained in this derivative work.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,12 @@
 <h1 align="center">Welcome to Chainlit 👋</h1>
 
+> **⚠️ NOTICE: This is a custom fork of Chainlit**
+> 
+> This is a fork of the original [Chainlit project](https://github.com/Chainlit/chainlit) maintained by AKI
+> The original Chainlit is developed by The Chainlit team and is available at https://chainlit.io/
+> 
+> This fork maintains full compatibility with the original Chainlit API.
+
 <p align="center">
 <b>Build python production-ready conversational AI applications in minutes, not weeks ⚡️</b>
 
@@ -40,18 +47,20 @@ https://github.com/user-attachments/assets/b3738aba-55c0-42fa-ac00-6efd1ee0d148
 Open a terminal and run:
 
 ```sh
-pip install chainlit
+pip install chainlit-aki
 chainlit hello
 ```
 
 If this opens the `hello app` in your browser, you're all set!
+
+**Note:** This fork maintains full API compatibility with the original Chainlit. You can still use `import chainlit as cl` in your code.
 
 ### Development version
 
 The latest in-development version can be installed straight from GitHub with:
 
 ```sh
-pip install git+https://github.com/Chainlit/chainlit.git#subdirectory=backend/
+pip install git+https://github.com/zhou-san/chainlit.git#subdirectory=backend/
 ```
 
 (Requires Node and pnpm installed on the system.)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "chainlit"
+name = "chainlit-aki"
 version = "2.6.2"
 keywords = [
     'LLM',
@@ -13,10 +13,10 @@ keywords = [
     'langchain',
     'conversational ai',
 ]
-description = "Build Conversational AI."
+description = "Build Conversational AI. (Custom fork of Chainlit for Aki)"
 authors = ["Willy Douhard", "Dan Andre Constantini"]
 license = "Apache-2.0"
-homepage = "https://chainlit.io/"
+homepage = "https://github.com/zhou-san/chainlit"
 documentation = "https://docs.chainlit.io/"
 classifiers = [
     "Framework :: FastAPI",
@@ -27,8 +27,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Environment :: Web Environment"
 ]
-repository = "https://github.com/Chainlit/chainlit"
+repository = "https://github.com/zhou-san/chainlit"
 readme = "README.md"
+packages = [{include = "chainlit"}]
 exclude = ["chainlit/frontend/**/*", "chainlit/copilot/**/**/"]
 include = [
     { path = "chainlit/frontend/dist/**/*", format = ["sdist", "wheel"] },


### PR DESCRIPTION
This PR adds configuration to publish chainlit as 'chainlit-aki' package to PyPI while maintaining full API compatibility.

Changes:
- Update package name to chainlit-aki in pyproject.toml
- Add NOTICE file for Apache 2.0 compliance  
- Update README.md with fork notice and installation instructions
- Update GitHub Actions workflow for custom package publishing
- Maintain full API compatibility with original Chainlit

Users can install with `pip install chainlit-aki` but still use `import chainlit` in their code.