### PR TITLE
feat: add new context panel for context management

### DIFF
--- a/backend/chainlit/__init__.py
+++ b/backend/chainlit/__init__.py
@@ -23,6 +23,7 @@ from chainlit.action import Action
 from chainlit.cache import cache
 from chainlit.chat_context import chat_context
 from chainlit.chat_settings import ChatSettings
+from chainlit.context_settings import ContextSettings
 from chainlit.context import context
 from chainlit.element import (
     Audio,
@@ -76,6 +77,7 @@ from .callbacks import (
     on_mcp_disconnect,
     on_message,
     on_settings_update,
+    on_context_update,
     on_shared_thread_view,
     on_stop,
     on_window_message,
@@ -177,6 +179,7 @@ __all__ = [
     "ChatGeneration",
     "ChatProfile",
     "ChatSettings",
+    "ContextSettings",
     "CompletionGeneration",
     "CopilotFunction",
     "CustomElement",
@@ -232,6 +235,7 @@ __all__ = [
     "on_mcp_disconnect",
     "on_message",
     "on_settings_update",
+    "on_context_update",
     "on_shared_thread_view",
     "on_stop",
     "on_window_message",

--- a/backend/chainlit/callbacks.py
+++ b/backend/chainlit/callbacks.py
@@ -445,6 +445,40 @@ def on_settings_update(
     return func
 
 
+def on_context_update(
+    func: Callable[[Dict[str, Any]], Any],
+) -> Callable[[Dict[str, Any]], Any]:
+    """
+    Hook to react to the user changing context settings.
+
+    Args:
+        func (Callable[[Dict[str, Any]], Any]): The hook to execute after context was changed.
+                                                 Receives context data including:
+                                                 - active_context: str - name of active context
+                                                 - selected_files: List[str] - list of active file names
+                                                 - context_params: Dict[str, Any] - context parameters
+
+    Example:
+        @cl.on_context_update
+        async def handle_context_change(context_data):
+            active_context = context_data.get("active_context")
+            selected_files = context_data.get("selected_files", [])
+
+            if active_context == "research":
+                # Process research documents
+                await process_research_files(selected_files)
+            elif active_context == "coding":
+                # Process code files
+                await process_code_files(selected_files)
+
+    Returns:
+        Callable[[Dict[str, Any]], Any]: The decorated hook.
+    """
+
+    config.code.on_context_update = wrap_user_function(func, with_task=True)
+    return func
+
+
 def data_layer(
     func: Callable[[], BaseDataLayer],
 ) -> Callable[[], BaseDataLayer]:

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -139,6 +139,10 @@ reaction_on_message_received = false
     # Sample rate of the audio
     sample_rate = 24000
 
+[features.context]
+    # Enable context management features
+    enabled = true
+
 [features.mcp]
     enabled = false
     show_indicator = true  # Control visibility of the MCP connection indicator dot
@@ -301,6 +305,10 @@ class TokenBatchingFeature(BaseModel):
     batch_window: int = 100  # Time window for collecting tokens (ms)
 
 
+class ContextFeature(BaseModel):
+    enabled: bool = True
+
+
 class McpFeature(BaseModel):
     enabled: bool = False
     show_indicator: bool = True  # Add option to toggle MCP indicator visibility
@@ -314,6 +322,7 @@ class McpFeature(BaseModel):
 class FeaturesSettings(BaseModel):
     spontaneous_file_upload: Optional[SpontaneousFileUploadFeature] = None
     audio: Optional[AudioFeature] = Field(default_factory=AudioFeature)
+    context: ContextFeature = Field(default_factory=ContextFeature)
     mcp: McpFeature = Field(default_factory=McpFeature)
     slack: SlackFeature = Field(default_factory=SlackFeature)
     token_batching: TokenBatchingFeature = Field(default_factory=TokenBatchingFeature)
@@ -390,6 +399,7 @@ class CodeSettings(BaseModel):
     on_mcp_connect: Optional[Callable] = None
     on_mcp_disconnect: Optional[Callable] = None
     on_settings_update: Optional[Callable[[Dict[str, Any]], Any]] = None
+    on_context_update: Optional[Callable[[Dict[str, Any]], Any]] = None
     set_chat_profiles: Optional[
         Callable[[Optional["User"], Optional["str"]], Awaitable[List["ChatProfile"]]]
     ] = None

--- a/backend/chainlit/context_settings.py
+++ b/backend/chainlit/context_settings.py
@@ -1,0 +1,34 @@
+from typing import List
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+from chainlit.context import context
+from chainlit.input_widget import InputWidget
+
+
+@dataclass
+class ContextSettings:
+    """Useful to create context settings that the user can change."""
+
+    inputs: List[InputWidget] = Field(default_factory=list, exclude=True)
+
+    def __init__(
+        self,
+        inputs: List[InputWidget],
+    ) -> None:
+        self.inputs = inputs
+
+    def settings(self):
+        return dict(
+            [(input_widget.id, input_widget.initial) for input_widget in self.inputs]
+        )
+
+    async def send(self):
+        settings = self.settings()
+        context.emitter.set_context_settings(settings)
+
+        inputs_content = [input_widget.to_dict() for input_widget in self.inputs]
+        await context.emitter.emit("context_settings", inputs_content)
+
+        return settings

--- a/backend/chainlit/emitter.py
+++ b/backend/chainlit/emitter.py
@@ -138,6 +138,10 @@ class BaseChainlitEmitter:
         """Stub method to set chat settings."""
         pass
 
+    async def set_context_settings(self, settings: dict):
+        """Stub method to set context settings."""
+        pass
+
     async def set_commands(self, commands: List[CommandDict]):
         """Stub method to send the available commands to the UI."""
         pass
@@ -430,6 +434,9 @@ class ChainlitEmitter(BaseChainlitEmitter):
 
     def set_chat_settings(self, settings: Dict[str, Any]):
         self.session.chat_settings = settings
+
+    def set_context_settings(self, settings: Dict[str, Any]):
+        self.session.context_settings = settings
 
     def set_commands(self, commands: List[CommandDict]):
         """Send the available commands to the UI."""

--- a/backend/chainlit/input_widget.py
+++ b/backend/chainlit/input_widget.py
@@ -367,3 +367,90 @@ class FileUpload(InputWidget):
             "tooltip": self.tooltip,
             "description": self.description,
         }
+
+
+@dataclass
+class ContextSelect(InputWidget):
+    """Useful to create a context selector input."""
+
+    type: InputWidgetType = "context_select"
+    initial: Optional[str] = None
+    values: List[str] = Field(default_factory=list)
+    items: Dict[str, str] = Field(default_factory=dict)
+
+    def __post_init__(
+        self,
+    ) -> None:
+        super().__post_init__()
+
+        if not self.values and not self.items:
+            raise ValueError("Must provide values or items to create a ContextSelect")
+
+        if self.values and self.items:
+            raise ValueError(
+                "You can only provide either values or items to create a ContextSelect"
+            )
+
+        if self.values:
+            self.items = {value: value for value in self.values}
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "id": self.id,
+            "label": self.label,
+            "initial": self.initial,
+            "items": [
+                {"label": id, "value": value} for id, value in self.items.items()
+            ],
+            "tooltip": self.tooltip,
+            "description": self.description,
+        }
+
+
+@dataclass
+class ContextFileManager(InputWidget):
+    """Useful to create a context-aware file manager combining upload and selection."""
+
+    type: InputWidgetType = "context_file_manager"
+    accept: Any = Field(default_factory=lambda: {"*/*": []})
+    max_files: int = 5
+    max_size_mb: int = 10
+    uploaded_files: List[str] = Field(default_factory=list)
+    selected_files: Optional[List[str]] = Field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "id": self.id,
+            "label": self.label,
+            "accept": self.accept,
+            "max_files": self.max_files,
+            "max_size_mb": self.max_size_mb,
+            "uploaded_files": self.uploaded_files,
+            "selected_files": self.selected_files,
+            "tooltip": self.tooltip,
+            "description": self.description,
+        }
+
+
+@dataclass
+class ContextTextArea(InputWidget):
+    """Useful to create a context description or parameters text area."""
+
+    type: InputWidgetType = "context_textarea"
+    initial: Optional[str] = None
+    placeholder: Optional[str] = None
+    rows: int = 4
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "id": self.id,
+            "label": self.label,
+            "initial": self.initial,
+            "placeholder": self.placeholder,
+            "rows": self.rows,
+            "tooltip": self.tooltip,
+            "description": self.description,
+        }

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -801,6 +801,8 @@ async def project_translations(
 
     # Load translation based on the provided language
     translation = config.load_translation(language)
+    print(f"Language: {language}")
+    print(f"translation {translation["chat"]}")
 
     return JSONResponse(
         content={

--- a/backend/chainlit/session.py
+++ b/backend/chainlit/session.py
@@ -4,7 +4,18 @@ import mimetypes
 import re
 import shutil
 import uuid
-from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    TypedDict,
+    Union,
+)
 
 import aiofiles
 
@@ -17,6 +28,19 @@ if TYPE_CHECKING:
     from chainlit.user import PersistedUser, User
 
 ClientType = Literal["webapp", "copilot", "teams", "slack", "discord"]
+
+
+class ContextData(TypedDict):
+    """Data structure for storing context information."""
+
+    id: str
+    name: str
+    description: Optional[str]
+    associated_files: List[str]  # List of file IDs associated with this context
+    active_files: List[str]  # List of currently active file IDs
+    parameters: Dict[str, Any]  # Context-specific parameters
+    created_at: str
+    updated_at: str
 
 
 class JSONEncoderIgnoreNonSerializable(json.JSONEncoder):
@@ -85,6 +109,11 @@ class BaseSession:
 
         self.chat_settings: Dict[str, Any] = {}
 
+        # Context management
+        self.contexts: Dict[str, ContextData] = {}
+        self.active_context: Optional[str] = None
+        self.context_settings: Dict[str, Any] = {}
+
     @property
     def files_dir(self):
         from chainlit.config import FILES_DIRECTORY
@@ -110,15 +139,17 @@ class BaseSession:
         # Use original filename instead of UUID, with proper sanitization
         import re
         from pathlib import Path
-        
+
         # Sanitize the filename to prevent directory traversal and invalid characters
-        sanitized_name = re.sub(r'[<>:"/\\|?*]', '_', name)
-        sanitized_name = sanitized_name.strip('. ')  # Remove leading/trailing dots and spaces
-        
+        sanitized_name = re.sub(r'[<>:"/\\|?*]', "_", name)
+        sanitized_name = sanitized_name.strip(
+            ". "
+        )  # Remove leading/trailing dots and spaces
+
         # Ensure filename is not empty after sanitization or only contains underscores
-        if not sanitized_name or sanitized_name.replace('_', '').strip() == '':
+        if not sanitized_name or sanitized_name.replace("_", "").strip() == "":
             sanitized_name = f"file_{file_id[:8]}"
-        
+
         file_path = self.files_dir / sanitized_name
 
         # Handle filename conflicts by adding a counter suffix
@@ -156,6 +187,85 @@ class BaseSession:
         }
 
         return {"id": file_id}
+
+    def create_context(
+        self,
+        name: str,
+        description: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Create a new context."""
+        from chainlit.utils import utc_now
+
+        context_id = str(uuid.uuid4())
+        self.contexts[context_id] = {
+            "id": context_id,
+            "name": name,
+            "description": description,
+            "associated_files": [],
+            "active_files": [],
+            "parameters": parameters or {},
+            "created_at": utc_now(),
+            "updated_at": utc_now(),
+        }
+
+        # Set as active context if it's the first one
+        if not self.active_context:
+            self.active_context = context_id
+
+        return context_id
+
+    def switch_context(self, context_id: str) -> bool:
+        """Switch to a different context."""
+        if context_id in self.contexts:
+            self.active_context = context_id
+            return True
+        return False
+
+    def get_active_context(self) -> Optional[ContextData]:
+        """Get the currently active context."""
+        if self.active_context and self.active_context in self.contexts:
+            return self.contexts[self.active_context]
+        return None
+
+    def add_file_to_context(self, context_id: str, file_id: str) -> bool:
+        """Associate a file with a context."""
+        if context_id in self.contexts and file_id in self.files:
+            if file_id not in self.contexts[context_id]["associated_files"]:
+                self.contexts[context_id]["associated_files"].append(file_id)
+                self.contexts[context_id]["updated_at"] = self._get_current_time()
+            return True
+        return False
+
+    def set_active_files_for_context(
+        self, context_id: str, file_ids: List[str]
+    ) -> bool:
+        """Set which files are active for a specific context."""
+        if context_id in self.contexts:
+            # Validate that all file_ids are associated with this context
+            associated_files = self.contexts[context_id]["associated_files"]
+            valid_file_ids = [fid for fid in file_ids if fid in associated_files]
+
+            self.contexts[context_id]["active_files"] = valid_file_ids
+            self.contexts[context_id]["updated_at"] = self._get_current_time()
+            return True
+        return False
+
+    def update_context_parameters(
+        self, context_id: str, parameters: Dict[str, Any]
+    ) -> bool:
+        """Update parameters for a specific context."""
+        if context_id in self.contexts:
+            self.contexts[context_id]["parameters"].update(parameters)
+            self.contexts[context_id]["updated_at"] = self._get_current_time()
+            return True
+        return False
+
+    def _get_current_time(self) -> str:
+        """Get current time as string."""
+        from chainlit.utils import utc_now
+
+        return utc_now()
 
     def to_persistable(self) -> Dict:
         from chainlit.config import config

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -397,3 +397,12 @@ async def change_settings(sid, settings: Dict[str, Any]):
 
     if config.code.on_settings_update:
         await config.code.on_settings_update(settings)
+
+
+@sio.on("context_settings_change")
+async def change_context_settings(sid, context_data: Dict[str, Any]):
+    """Handle context settings submit from the UI."""
+    context = init_ws_context(sid)
+
+    if config.code.on_context_update:
+        await config.code.on_context_update(context_data)

--- a/backend/chainlit/translations/en-US.json
+++ b/backend/chainlit/translations/en-US.json
@@ -62,7 +62,8 @@
       "actions": {
         "send": "Send message",
         "stop": "Stop Task",
-        "attachFiles": "Attach files"
+        "attachFiles": "Attach files",
+        "manageContexts": "Manage contexts"
       }
     },
     "commands": {
@@ -122,6 +123,10 @@
     "settings": {
       "title": "Settings panel",
       "customize": "Customize your chat settings here"
+    },
+    "contexts": {
+      "title": "Context panel",
+      "customize": "Manage your contexts and files here"
     },
     "watermark": "LLMs can make mistakes. Check important info."
   },

--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -34,6 +34,9 @@ InputWidgetType = Literal[
     "checkbox",
     "radio",
     "fileupload",
+    "context_select",
+    "context_file_manager",
+    "context_textarea",
 ]
 ToastType = Literal["info", "success", "warning", "error"]
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { router } from 'router';
 import { useAuth, useChatSession, useConfig } from '@chainlit/react-client';
 
 import ChatSettingsModal from './components/ChatSettings';
+import ContextSettingsModal from './components/ContextSettings';
 import { ThemeProvider } from './components/ThemeProvider';
 import { Loader } from '@/components/Loader';
 import { Toaster } from '@/components/ui/sonner';
@@ -81,6 +82,7 @@ function App() {
       <Toaster richColors className="toast" position="top-right" />
 
       <ChatSettingsModal />
+      <ContextSettingsModal />
       <RouterProvider router={router} />
 
       <div

--- a/frontend/src/components/ChatSettings/FileUploadInput.tsx
+++ b/frontend/src/components/ChatSettings/FileUploadInput.tsx
@@ -1,6 +1,8 @@
 import { Upload, X } from 'lucide-react';
 import { useState } from 'react';
 
+import { useChatInteract } from '@chainlit/react-client';
+
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 
@@ -33,7 +35,10 @@ const FileUploadInput = ({
   max_files = 1,
   max_size_mb = 2
 }: FileUploadInputProps): JSX.Element => {
+  const { uploadFile } = useChatInteract();
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [uploadedFiles, setUploadedFiles] = useState<{id: string, name: string}[]>([]);
+  const [uploading, setUploading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
 
   const fileSpec: FileSpec = {
@@ -42,7 +47,12 @@ const FileUploadInput = ({
     max_size_mb
   };
 
-  const onResolved = (files: File[]) => {
+  const onResolved = async (files: File[]) => {
+    // Prevent duplicate uploads
+    if (uploading) {
+      return;
+    }
+
     // Handle adding to existing files for multiple file support
     const newFiles = max_files > 1 ? [...selectedFiles, ...files] : files;
 
@@ -50,9 +60,38 @@ const FileUploadInput = ({
     const limitedFiles = newFiles.slice(0, max_files);
 
     setSelectedFiles(limitedFiles);
-    const fileNames = limitedFiles.map((file) => file.name);
-    setField?.(id, fileNames);
+    setUploading(true);
     setError('');
+
+    try {
+      // Upload each file to the backend sequentially to avoid promise issues
+      const uploadResults = [];
+      for (const file of limitedFiles) {
+        const upload = uploadFile(file, () => {}); // Returns {xhr, promise}
+        const result = await upload.promise; // Await the actual promise
+        uploadResults.push(result);
+      }
+
+      // Store uploaded file info using IDs from upload response
+      const newUploadedFiles = uploadResults
+        .filter((result) => result && result.id)
+        .map((result, index) => ({
+          id: result.id,
+          name: limitedFiles[index].name
+        }));
+
+      setUploadedFiles(newUploadedFiles);
+
+      // Store file IDs in form field
+      const fileIds = newUploadedFiles.map((file) => file.id);
+      setField?.(id, fileIds);
+
+    } catch (error) {
+      console.error('Upload error:', error);
+      setError(`Upload failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setUploading(false);
+    }
 
     // Show warning if files were truncated
     if (newFiles.length > max_files) {
@@ -73,13 +112,18 @@ const FileUploadInput = ({
 
   const handleRemoveFile = (index: number) => {
     const newFiles = selectedFiles.filter((_, i) => i !== index);
+    const newUploadedFiles = uploadedFiles.filter((_, i) => i !== index);
+
     setSelectedFiles(newFiles);
-    const fileNames = newFiles.map((file) => file.name);
-    setField?.(id, fileNames);
+    setUploadedFiles(newUploadedFiles);
+
+    const fileIds = newUploadedFiles.map((file) => file.id);
+    setField?.(id, fileIds);
   };
 
   const handleClearAll = () => {
     setSelectedFiles([]);
+    setUploadedFiles([]);
     setField?.(id, []);
     setError('');
   };
@@ -100,9 +144,9 @@ const FileUploadInput = ({
         <Card className="border-dashed border-2 hover:border-primary/50 transition-colors">
           <div
             {...getRootProps()}
-            className="flex items-center justify-center p-4 cursor-pointer"
+            className={`flex items-center justify-center p-4 ${uploading || disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
           >
-            <input {...getInputProps()} disabled={disabled} />
+            <input {...getInputProps()} disabled={disabled || uploading} />
             <div className="text-center">
               <Upload className="mx-auto h-8 w-8 text-muted-foreground mb-2" />
               <p className="text-sm text-muted-foreground">
@@ -123,11 +167,15 @@ const FileUploadInput = ({
 
         {error && <div className="text-sm text-destructive">{error}</div>}
 
-        {selectedFiles.length > 0 && (
+        {uploading && (
+          <div className="text-sm text-muted-foreground">Uploading files...</div>
+        )}
+
+        {uploadedFiles.length > 0 && !uploading && (
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <p className="text-sm font-medium">
-                Selected Files ({selectedFiles.length}/{max_files}):
+                Uploaded Files ({uploadedFiles.length}/{max_files}):
               </p>
               <Button
                 type="button"
@@ -140,7 +188,7 @@ const FileUploadInput = ({
               </Button>
             </div>
             <div className="space-y-1">
-              {selectedFiles.map((file, index) => (
+              {uploadedFiles.map((file, index) => (
                 <div
                   key={index}
                   className="flex items-center justify-between p-2 bg-muted rounded-md"
@@ -148,7 +196,7 @@ const FileUploadInput = ({
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium truncate">{file.name}</p>
                     <p className="text-xs text-muted-foreground">
-                      {(file.size / 1024 / 1024).toFixed(2)} MB • {file.type || 'Unknown type'}
+                      Uploaded successfully • ID: {file.id}
                     </p>
                   </div>
                   <Button

--- a/frontend/src/components/ChatSettings/FormInput.tsx
+++ b/frontend/src/components/ChatSettings/FormInput.tsx
@@ -27,16 +27,21 @@ type TFormInput =
   | (Omit<TagsInputProps, 'value'> & IFormInput<'tags', string[]>)
   | (Omit<SecureTagsInputProps, 'value'> & IFormInput<'secure_tags', string[]>)
   | (Omit<SelectInputProps, 'value'> & IFormInput<'select', string>)
+  | (Omit<SelectInputProps, 'value'> & IFormInput<'context_select', string>)
   | (Omit<TextInputProps, 'value'> & IFormInput<'textinput', string>)
+  | (Omit<TextInputProps, 'value'> & IFormInput<'context_textarea', string>)
   | (Omit<TextInputProps, 'value'> & IFormInput<'numberinput', number>)
   | (Omit<MultiSelectInputProps, 'value'> & IFormInput<'multiselect', string[]>)
   | (Omit<CheckboxInputProps, 'checked'> & IFormInput<'checkbox', boolean>)
   | (Omit<RadioButtonGroupProps, 'value'> & IFormInput<'radio', string>)
-  | (Omit<FileUploadInputProps, 'value'> & IFormInput<'fileupload', string[]>);
+  | (Omit<FileUploadInputProps, 'value'> & IFormInput<'fileupload', string[]>)
+  | (Omit<FileUploadInputProps, 'value'> & IFormInput<'context_file_manager', string[]>);
 
 const FormInput = ({ element }: { element: TFormInput }): JSX.Element => {
   switch (element?.type) {
     case 'select':
+      return <SelectInput {...element} value={element.value ?? ''} />;
+    case 'context_select':
       return <SelectInput {...element} value={element.value ?? ''} />;
     case 'slider':
       return <SliderInput {...element} value={element.value ?? 0} />;
@@ -48,6 +53,8 @@ const FormInput = ({ element }: { element: TFormInput }): JSX.Element => {
       return <SwitchInput {...element} checked={!!element.value} />;
     case 'textinput':
       return <TextInput {...element} value={element.value ?? ''} />;
+    case 'context_textarea':
+      return <TextInput {...element} value={element.value ?? ''} multiline={true} />;
     case 'numberinput':
       return (
         <TextInput
@@ -63,6 +70,8 @@ const FormInput = ({ element }: { element: TFormInput }): JSX.Element => {
     case 'radio':
       return <RadioButtonGroup {...element} value={element.value ?? ''} />;
     case 'fileupload':
+      return <FileUploadInput {...element} value={element.value ?? []} />;
+    case 'context_file_manager':
       return <FileUploadInput {...element} value={element.value ?? []} />;
     default:
       // If the element type is not recognized, we indicate an unimplemented type.

--- a/frontend/src/components/ContextSettings/index.tsx
+++ b/frontend/src/components/ContextSettings/index.tsx
@@ -1,0 +1,115 @@
+import mapValues from 'lodash/mapValues';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+
+import {
+  useChatData,
+  useChatInteract
+} from '@chainlit/react-client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+import { Translator } from 'components/i18n';
+
+import { contextSettingsOpenState } from 'state/project';
+
+import { FormInput, TFormInputValue } from '../ChatSettings/FormInput';
+
+export default function ContextSettingsModal() {
+  const { contextSettingsValue, contextSettingsInputs, contextSettingsDefaultValue } =
+    useChatData();
+
+  const { updateContextSettings } = useChatInteract();
+
+  const [contextSettingsOpen, setContextSettingsOpen] = useRecoilState(
+    contextSettingsOpenState
+  );
+
+  const { handleSubmit, setValue, reset, watch } = useForm({
+    defaultValues: contextSettingsValue
+  });
+
+  // Reset form when default values change
+  useEffect(() => {
+    reset(contextSettingsValue);
+  }, [contextSettingsValue, reset]);
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      reset(contextSettingsValue);
+      setContextSettingsOpen(false);
+    }
+  };
+
+  const handleConfirm = handleSubmit((data) => {
+    const processedValues = mapValues(data, (x: TFormInputValue) =>
+      x !== '' ? x : null
+    );
+    updateContextSettings(processedValues);
+    setContextSettingsOpen(false);
+  });
+
+  const handleReset = () => {
+    reset(contextSettingsDefaultValue);
+  };
+
+  // Legacy setField compatibility layer
+  const handleChange = () => {};
+
+  const setFieldValue = (field: string, value: any) => {
+    setValue(field, value);
+  };
+
+  const values = watch();
+
+  return (
+    <Dialog open={contextSettingsOpen} onOpenChange={handleClose}>
+      <DialogContent
+        id="context-settings"
+        className="min-w-[20vw] max-h-[85vh] flex flex-col gap-6 p-6"
+      >
+        <DialogHeader>
+          <DialogTitle>
+            <Translator path="chat.contexts.title" />
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            <Translator path="chat.contexts.customize" />
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col flex-grow overflow-y-auto gap-6 p-1">
+          {contextSettingsInputs.map((input: any) => (
+            <FormInput
+              key={input.id}
+              element={{
+                ...input,
+                value: values[input.id],
+                onChange: handleChange,
+                setField: setFieldValue
+              }}
+            />
+          ))}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleReset}>
+            <Translator path="common.actions.reset" />
+          </Button>
+          <div className="flex-1" />
+          <Button variant="ghost" onClick={() => handleClose(false)}>
+            <Translator path="common.actions.cancel" />
+          </Button>
+          <Button onClick={handleConfirm} id="confirm" autoFocus>
+            <Translator path="common.actions.confirm" />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/chat/MessageComposer/ContextButton.tsx
+++ b/frontend/src/components/chat/MessageComposer/ContextButton.tsx
@@ -1,0 +1,56 @@
+import { useSetRecoilState } from 'recoil';
+import { BookOpen } from 'lucide-react';
+
+import { useConfig } from '@chainlit/react-client';
+
+import { Translator } from '@/components/i18n';
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@/components/ui/tooltip';
+
+import { contextSettingsOpenState } from '@/state/project';
+
+interface ContextButtonProps {
+  disabled?: boolean;
+}
+
+export const ContextButton = ({ disabled = false }: ContextButtonProps) => {
+  const { config } = useConfig();
+  const setContextSettingsOpen = useSetRecoilState(contextSettingsOpenState);
+
+  const isContextEnabled = !!config?.features.context?.enabled;
+
+  if (!isContextEnabled) return null;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-block">
+            <Button
+              id={disabled ? 'context-button-loading' : 'context-button'}
+              variant="ghost"
+              size="icon"
+              className="hover:bg-muted rounded-full"
+              disabled={disabled}
+              onClick={() => setContextSettingsOpen(true)}
+            >
+              <BookOpen className="h-6 w-6" />
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            <Translator path="chat.input.actions.manageContexts" />
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export default ContextButton;

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -14,7 +14,7 @@ import { Settings } from '@/components/icons/Settings';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from 'components/i18n/Translator';
 
-import { chatSettingsOpenState } from '@/state/project';
+import { chatSettingsOpenState, contextSettingsOpenState } from '@/state/project';
 import {
   IAttachment,
   attachmentsState,
@@ -24,6 +24,7 @@ import {
 import { Attachments } from './Attachments';
 import CommandButtons from './CommandButtons';
 import CommandButton from './CommandPopoverButton';
+import ContextButton from './ContextButton';
 import Input, { InputMethods } from './Input';
 import McpButton from './Mcp';
 import SubmitButton from './SubmitButton';
@@ -54,7 +55,7 @@ export default function MessageComposer({
 
   const { user } = useAuth();
   const { sendMessage, replyMessage } = useChatInteract();
-  const { askUser, chatSettingsInputs, disabled: _disabled } = useChatData();
+  const { askUser, chatSettingsInputs, contextSettingsInputs, disabled: _disabled } = useChatData();
 
   const disabled = _disabled || !!attachments.find((a) => !a.uploaded);
 
@@ -195,6 +196,9 @@ export default function MessageComposer({
             >
               <Settings className="!size-6" />
             </Button>
+          )}
+          {contextSettingsInputs.length > 0 && (
+            <ContextButton disabled={disabled} />
           )}
           <McpButton disabled={disabled} />
           <CommandButton

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -4,3 +4,8 @@ export const chatSettingsOpenState = atom<boolean>({
   key: 'chatSettingsOpen',
   default: false
 });
+
+export const contextSettingsOpenState = atom<boolean>({
+  key: 'contextSettingsOpen',
+  default: false
+});

--- a/libs/react-client/src/state.ts
+++ b/libs/react-client/src/state.ts
@@ -143,6 +143,29 @@ export const chatSettingsValueState = atom({
   default: chatSettingsDefaultValueSelector
 });
 
+export const contextSettingsInputsState = atom<any>({
+  key: 'ContextSettings',
+  default: []
+});
+
+export const contextSettingsDefaultValueSelector = selector({
+  key: 'ContextSettingsValue/Default',
+  get: ({ get }) => {
+    const contextSettings = get(contextSettingsInputsState);
+    return contextSettings.reduce(
+      (form: { [key: string]: any }, input: any) => (
+        (form[input.id] = input.initial), form
+      ),
+      {}
+    );
+  }
+});
+
+export const contextSettingsValueState = atom({
+  key: 'ContextSettingsValue',
+  default: contextSettingsDefaultValueSelector
+});
+
 export const elementState = atom<IMessageElement[]>({
   key: 'DisplayElements',
   default: []

--- a/libs/react-client/src/useChatData.ts
+++ b/libs/react-client/src/useChatData.ts
@@ -7,6 +7,9 @@ import {
   chatSettingsDefaultValueSelector,
   chatSettingsInputsState,
   chatSettingsValueState,
+  contextSettingsDefaultValueSelector,
+  contextSettingsInputsState,
+  contextSettingsValueState,
   elementState,
   loadingState,
   sessionState,
@@ -33,6 +36,11 @@ const useChatData = () => {
   const chatSettingsDefaultValue = useRecoilValue(
     chatSettingsDefaultValueSelector
   );
+  const contextSettingsInputs = useRecoilValue(contextSettingsInputsState);
+  const contextSettingsValue = useRecoilValue(contextSettingsValueState);
+  const contextSettingsDefaultValue = useRecoilValue(
+    contextSettingsDefaultValueSelector
+  );
 
   const connected = session?.socket.connected && !session?.error;
   const disabled =
@@ -49,6 +57,9 @@ const useChatData = () => {
     chatSettingsDefaultValue,
     chatSettingsInputs,
     chatSettingsValue,
+    contextSettingsDefaultValue,
+    contextSettingsInputs,
+    contextSettingsValue,
     connected,
     disabled,
     elements,

--- a/libs/react-client/src/useChatInteract.ts
+++ b/libs/react-client/src/useChatInteract.ts
@@ -141,6 +141,13 @@ const useChatInteract = () => {
     [session?.socket]
   );
 
+  const updateContextSettings = useCallback(
+    (values: object) => {
+      session?.socket.emit('context_settings_change', values);
+    },
+    [session?.socket]
+  );
+
   const stopTask = useCallback(() => {
     setMessages((oldMessages) =>
       oldMessages.map((m) => {
@@ -173,7 +180,8 @@ const useChatInteract = () => {
     endAudioStream,
     stopTask,
     setIdToResume,
-    updateChatSettings
+    updateChatSettings,
+    updateContextSettings
   };
 };
 

--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -16,6 +16,8 @@ import {
   chatProfileState,
   chatSettingsInputsState,
   chatSettingsValueState,
+  contextSettingsInputsState,
+  contextSettingsValueState,
   commandsState,
   currentThreadIdState,
   elementState,
@@ -105,6 +107,7 @@ const useChatSession = () => {
   const setAudioConnection = useSetRecoilState(audioConnectionState);
   const resetChatSettingsValue = useResetRecoilState(chatSettingsValueState);
   const setChatSettingsValue = useSetRecoilState(chatSettingsValueState);
+  const resetContextSettingsValue = useResetRecoilState(contextSettingsValueState);
   const setFirstUserInteraction = useSetRecoilState(firstUserInteraction);
   const setLoading = useSetRecoilState(loadingState);
   const setMcps = useSetRecoilState(mcpState);
@@ -119,6 +122,7 @@ const useChatSession = () => {
   const setTasklists = useSetRecoilState(tasklistState);
   const setActions = useSetRecoilState(actionState);
   const setChatSettingsInputs = useSetRecoilState(chatSettingsInputsState);
+  const setContextSettingsInputs = useSetRecoilState(contextSettingsInputsState);
   const setTokenCount = useSetRecoilState(tokenCountState);
   const [chatProfile, setChatProfile] = useRecoilState(chatProfileState);
   const idToResume = useRecoilValue(threadIdToResumeState);
@@ -541,6 +545,11 @@ const useChatSession = () => {
       socket.on('chat_settings', (inputs: any) => {
         setChatSettingsInputs(inputs);
         resetChatSettingsValue();
+      });
+
+      socket.on('context_settings', (inputs: any) => {
+        setContextSettingsInputs(inputs);
+        resetContextSettingsValue();
       });
 
       socket.on('set_commands', (commands: ICommand[]) => {


### PR DESCRIPTION
add new context panel for context management

### Context Button 
<img width="968" height="128" alt="image" src="https://github.com/user-attachments/assets/50e3dd92-653d-4488-a8b6-5df7ff726c71" />

### Context panel example (Configurable)
<img width="533" height="764" alt="image" src="https://github.com/user-attachments/assets/5a3bcf6b-e9b2-4b15-8491-e63a3f6c9105" />

### File Upload
After file is uploaded, you will be able to get the files via `chainlit.context.session.files` and inside the hooks, you will get `file_ids`
